### PR TITLE
[OPS-824] Update issues icons and colors

### DIFF
--- a/asset/css/style.css
+++ b/asset/css/style.css
@@ -297,12 +297,16 @@ main {
     fill: #6fa85d;
 }
 
-#mf-cross-s, .issue-closed{
+#mf-cross-s {
     fill: #b12c2c;
 }
 
+.issue-closed {
+    fill: #9261f2;
+}
+
 /* some styles to make the page responsive */
-@media screen and (max-width: 800px){
+@media screen and (max-width: 800px) {
     .top-row {
         flex-direction: column;
         align-items: center;

--- a/asset/js/issues.js
+++ b/asset/js/issues.js
@@ -31,13 +31,15 @@ function fillIssues(data, elem, individual = false) {
             img.innerHTML = 
             "<svg class=\"issue-opened\" viewBox=\"0 0 16 16\" version=\"1.1\" aria-hidden=\"true\">\
                 <title>This issue is currently opened</title>\
-                <path fill-rule=\"evenodd\" d=\"M8 1.5a6.5 6.5 0 100 13 6.5 6.5 0 000-13zM0 8a8 8 0 1116 0A8 8 0 010 8zm9 3a1 1 0 11-2 0 1 1 0 012 0zm-.25-6.25a.75.75 0 00-1.5 0v3.5a.75.75 0 001.5 0v-3.5z\"></path>\
+                <path d=\"M8 9.5a1.5 1.5 0 100-3 1.5 1.5 0 000 3z\"></path>\
+                <path fill-rule=\"evenodd\" d=\"M8 0a8 8 0 100 16A8 8 0 008 0zM1.5 8a6.5 6.5 0 1113 0 6.5 6.5 0 01-13 0z\"></path>\
             </svg>";
         }else if(issue.state === "closed"){
             img.innerHTML = 
             "<svg class=\"issue-closed\" viewBox=\"0 0 16 16\" version=\"1.1\" aria-hidden=\"true\">\
                 <title>This issue is currently closed</title>\
-                <path fill-rule=\"evenodd\" d=\"M1.5 8a6.5 6.5 0 0110.65-5.003.75.75 0 00.959-1.153 8 8 0 102.592 8.33.75.75 0 10-1.444-.407A6.5 6.5 0 011.5 8zM8 12a1 1 0 100-2 1 1 0 000 2zm0-8a.75.75 0 01.75.75v3.5a.75.75 0 11-1.5 0v-3.5A.75.75 0 018 4zm4.78 4.28l3-3a.75.75 0 00-1.06-1.06l-2.47 2.47-.97-.97a.749.749 0 10-1.06 1.06l1.5 1.5a.75.75 0 001.06 0z\"></path>\
+                <path d=\"M11.28 6.78a.75.75 0 00-1.06-1.06L7.25 8.69 5.78 7.22a.75.75 0 00-1.06 1.06l2 2a.75.75 0 001.06 0l3.5-3.5z\"></path>\
+                <path fill-rule=\"evenodd\" d=\"M16 8A8 8 0 110 8a8 8 0 0116 0zm-1.5 0a6.5 6.5 0 11-13 0 6.5 6.5 0 0113 0z\"></path>\
             </svg>";
         }
         title_div.append(title);


### PR DESCRIPTION
The issues icons and colors are now matching the GitHub ones.
(https://github.blog/changelog/2021-10-26-updates-to-our-issue-status-icons-and-colors/)